### PR TITLE
Suganuma

### DIFF
--- a/app/controllers/admin/records_controller.rb
+++ b/app/controllers/admin/records_controller.rb
@@ -42,7 +42,6 @@ class Admin::RecordsController < ArtistsController
 
   def create
     @record = Form::Record.new(record_params)
-    # binding.pry
     if @record.save
       redirect_to search_admin_records_path, notice: "レコード「#{@record.name}」を登録しました。"
     else

--- a/app/controllers/admin/records_controller.rb
+++ b/app/controllers/admin/records_controller.rb
@@ -42,6 +42,7 @@ class Admin::RecordsController < ArtistsController
 
   def create
     @record = Form::Record.new(record_params)
+    # binding.pry
     if @record.save
       redirect_to search_admin_records_path, notice: "レコード「#{@record.name}」を登録しました。"
     else
@@ -76,12 +77,7 @@ class Admin::RecordsController < ArtistsController
   end
 
   def record_params
-    params
-      .require(:form_record)
-      .permit(
-        Form::Record::REGISTRABLE_ATTRIBUTES +
-        [tunes_attributes: Form::Tune::REGISTRABLE_ATTRIBUTES]
-      )
+    params.require(:form_record).permit(Form::Record::REGISTRABLE_ATTRIBUTES + [tunes_attributes: Form::Tune::REGISTRABLE_ATTRIBUTES])
   end
 
   def update_record_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
       :address,
       :post_number,
       :tel,
-      :hundlename,
+      :handlename,
       ]
     )
   end

--- a/app/models/tune.rb
+++ b/app/models/tune.rb
@@ -1,6 +1,6 @@
 class Tune < ApplicationRecord
 
-	validates :name, presence: true
+	validates :tune_name, presence: true
 
 	belongs_to :record
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
   validates :post_number, presence: true, format: {with: /\A\d{3}[-]\d{4}$|^\d{3}[-]\d{2}$|^\d{3}$|^\d{5}$|^\d{7}\z/ }
   validates :address, presence: true
   validates :tel, presence: true, format: { with: /\A\d+\d+\d+\z/ }
-  validates :handlename, presence: true, format: {with: /\A[ -~]+\z/}, length: { in: 1..10 }\\\\\\
+  validates :handlename, presence: true, format: {with: /\A[ -~]+\z/}, length: { in: 1..10 }
 
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,14 @@ class User < ApplicationRecord
   has_many :orders
   has_many :reviews, dependent: :destroy
 
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :first_name_kana, presence: true, format: {with: /[\p{katakana}　ー－]+/}
+  validates :last_name_kana, presence: true, format: {with: /[\p{katakana}　ー－]+/}
+  validates :post_number, presence: true, format: {with: /\A\d{3}[-]\d{4}$|^\d{3}[-]\d{2}$|^\d{3}$|^\d{5}$|^\d{7}\z/ }
+  validates :address, presence: true
+  validates :tel, presence: true, format: { with: /\A\d+\d+\d+\z/ }
+  validates :handlename, presence: true, format: {with: /\A[ -~]+\z/}, length: { in: 1..10 }
 
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
   validates :post_number, presence: true, format: {with: /\A\d{3}[-]\d{4}$|^\d{3}[-]\d{2}$|^\d{3}$|^\d{5}$|^\d{7}\z/ }
   validates :address, presence: true
   validates :tel, presence: true, format: { with: /\A\d+\d+\d+\z/ }
-  validates :handlename, presence: true, format: {with: /\A[ -~]+\z/}, length: { in: 1..10 }
+  validates :handlename, presence: true, format: {with: /\A[ -~]+\z/}, length: { in: 1..10 }\\\\\\
 
 
 end

--- a/app/views/admin/records/_form.html.erb
+++ b/app/views/admin/records/_form.html.erb
@@ -102,6 +102,7 @@
     
     </section>
 
+
     <div class="col-xs-12 text-center">
         <%= f.submit "上記を保存する", class:"btn btn-primary btn-lg artist-show-btn" %>
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -41,8 +41,8 @@
                       </div>
 
                       <div class="form-group has-icon">
-                        <label class="control-label sr-only" for="inputfhandlename">ニックネーム</label>
-                        <%= f.text_field :handlename, autofocus: true, class:"form-control", id:"inputhandlname", placeholder:"ニックネーム"%>
+                        <label class="control-label sr-only" for="inputhandlename">ニックネーム</label>
+                        <%= f.text_field :handlename, autofocus: true, class:"form-control", id:"inputhandlename", placeholder:"ニックネーム"%>
                       </div>
 
                       <div class="form-group has-icon">


### PR DESCRIPTION
商品登録ができない不具合を修正しました。
会員登録時ハンドルネームが登録されない不具合を修正しました。
商品登録時、曲名を入れないと登録できないようにしました。
新規登録時のバリデードを設定しました。
設定内容は以下の通りです。
姓名・・・空白不可
姓名カナ・・・カタカナ以外不可（全角半角区別なし）
郵便番号・・・半角数字、ハイフンはあってもなくてもOK
電話番号・・・半角数字、ハイフンは不可
ハンドルネーム・・・半角英数字＋記号のみ、１０文字まで